### PR TITLE
Fix compilation with kernel older than 4.15

### DIFF
--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -165,15 +165,16 @@ static inline VOID __RTMP_OS_Init_Timer(
 	IN TIMER_FUNCTION function,
 	IN PVOID data)
 {
- 	if (!timer_pending(&pTimer->t)) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
+	if (!timer_pending(pTimer)) {
  		init_timer(pTimer);
 		pTimer->data = (unsigned long)data;
 		pTimer->function = function;
+	}
 #else
+	if (!timer_pending(&pTimer->t))
 		timer_setup(&pTimer->t, function, 0);
 #endif
-	}
 }
 
 static inline VOID __RTMP_OS_Add_Timer(


### PR DESCRIPTION
With a kernel older than 4.15, `__RTMP_OS_Init_Timer` function raise a compilation error. This commit configures the involved macro properly.

```
/buildroot_platform_hardware_wifi_mtk_drivers_mt7603/os/linux/../../os/linux/rt_linux.c:` In function ‘__RTMP_OS_Init_Timer’:
/buildroot_platform_hardware_wifi_mtk_drivers_mt7603/os/linux/../../os/linux/rt_linux.c:168:29: error: ‘OS_NDIS_MINIPORT_TIMER {aka struct timer_list}’ has no member named ‘t’
   if (!timer_pending(&pTimer->t)) {
                             ^~
```